### PR TITLE
Always send SDID in getOffers even if visitor cookie is empty

### DIFF
--- a/java-sdk/src/main/java/com/adobe/target/edge/client/model/TargetDeliveryRequestBuilder.java
+++ b/java-sdk/src/main/java/com/adobe/target/edge/client/model/TargetDeliveryRequestBuilder.java
@@ -203,13 +203,12 @@ public final class TargetDeliveryRequestBuilder {
     private void setVisitorValues() {
         String visitorCookie = requestCookies.get(VisitorProvider.getInstance().getVisitorCookieName());
 
-        if (isEmpty(visitorCookie)) {
-            return;
-        }
-
         createAndSetVisitor(visitorCookie);
         Map<String, AmcvEntry> visitorValues = visitor.getVisitorValues();
-        marketingCloudVisitorId = visitorValues.get(MARKETING_CLOUD_VISITOR_ID).getValue();
+        AmcvEntry entry = visitorValues.get(MARKETING_CLOUD_VISITOR_ID);
+        if (entry != null) {
+            marketingCloudVisitorId = entry.getValue();
+        }
     }
 
     private void setExperienceCloudValues() {
@@ -246,10 +245,14 @@ public final class TargetDeliveryRequestBuilder {
         }
 
         Map<String, AmcvEntry> visitorValues = visitor.getVisitorValues();
-        int locationHint = Integer.parseInt(visitorValues.get(LOCATION_HINT).getValue());
-        String blob = visitorValues.get(BLOB).getValue();
-        AudienceManager audienceManager = new AudienceManager().blob(blob).locationHint(locationHint);
-        experienceCloud.audienceManager(audienceManager);
+        AmcvEntry locationHintEntry = visitorValues.get(LOCATION_HINT);
+        AmcvEntry blobEntry = visitorValues.get(BLOB);
+        if (locationHintEntry != null && blobEntry != null) {
+            int locationHint = Integer.parseInt(locationHintEntry.getValue());
+            String blob = blobEntry.getValue();
+            AudienceManager audienceManager = new AudienceManager().blob(blob).locationHint(locationHint);
+            experienceCloud.audienceManager(audienceManager);
+        }
     }
 
     private void setSessionId(final Map<String, String> parsedCookies) {

--- a/java-sdk/src/test/java/com/adobe/target/edge/client/entities/TargetDeliveryRequestTest.java
+++ b/java-sdk/src/test/java/com/adobe/target/edge/client/entities/TargetDeliveryRequestTest.java
@@ -197,11 +197,11 @@ class TargetDeliveryRequestTest {
         assertEquals(context, targetDeliveryRequest.getDeliveryRequest().getContext());
         assertEquals(mboxNotifications, targetDeliveryRequest.getDeliveryRequest().getNotifications());
 
-        assertNull(targetDeliveryRequest.getDeliveryRequest().getExperienceCloud());
+        verifyAnalyticsValues(targetDeliveryRequest);
 
         TargetDeliveryResponse targetDeliveryResponse = targetJavaClient.getOffers(targetDeliveryRequest);
         verifyServerStateAndNewCookie(targetDeliveryResponse, newSessionId);
-        assertTrue(targetDeliveryResponse.getVisitorState().isEmpty());
+        verifyVisitorState(targetDeliveryResponse, customerIds);
     }
 
     @Test
@@ -238,11 +238,11 @@ class TargetDeliveryRequestTest {
         assertEquals(context, targetDeliveryRequest.getDeliveryRequest().getContext());
         assertEquals(mboxNotifications, targetDeliveryRequest.getDeliveryRequest().getNotifications());
 
-        assertNull(targetDeliveryRequest.getDeliveryRequest().getExperienceCloud());
+        verifyAnalyticsValues(targetDeliveryRequest);
 
         TargetDeliveryResponse targetDeliveryResponse = targetJavaClient.getOffers(targetDeliveryRequest);
         verifyServerStateAndNewCookie(targetDeliveryResponse, newSessionId);
-        assertTrue(targetDeliveryResponse.getVisitorState().isEmpty());
+        verifyVisitorState(targetDeliveryResponse, customerIds);
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

To support A4T reporting in Target, we need the SDID to be sent to Target on the initial request, even if the user's visitor cookie hasn't been set yet. 

## Motivation and Context

This change ensures that data can be stitched together properly on an initial request when A4T is used for reporting.

## How Has This Been Tested?

I tested this locally using a Java Spring webapp with the Target Java SDK which sent requests to a production Target server.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
