### PR TITLE
TNT-38730 Remove clientCode URL params to Delivery API from Java SDK

### DIFF
--- a/src/main/java/com/adobe/target/edge/client/ClientConfig.java
+++ b/src/main/java/com/adobe/target/edge/client/ClientConfig.java
@@ -296,7 +296,6 @@ public class ClientConfig {
 
     public ClientConfig build() {
       ClientConfig clientConfig = new ClientConfig();
-      Objects.requireNonNull(client, "client id cannot be null");
       Objects.requireNonNull(organizationId, "organization id cannot be null");
       clientConfig.client = client;
       clientConfig.organizationId = this.organizationId;

--- a/src/main/java/com/adobe/target/edge/client/service/DefaultTargetService.java
+++ b/src/main/java/com/adobe/target/edge/client/service/DefaultTargetService.java
@@ -41,7 +41,7 @@ public class DefaultTargetService implements TargetService {
   public static final String SDK_USER_VALUE = "AdobeTargetJava";
   public static final String SDK_VERSION_KEY = "X-EXC-SDK-Version";
   public static final String SESSION_ID = "sessionId";
-  public static final String CLIENT = "client";
+  public static final String ORGANIZATION_ID = "organizationId";
   private final TargetHttpClient targetHttpClient;
   private final ClientConfig clientConfig;
   private String stickyLocationHint;
@@ -117,7 +117,7 @@ public class DefaultTargetService implements TargetService {
   private Map<String, Object> getQueryParams(TargetDeliveryRequest deliveryRequest) {
     Map<String, Object> queryParams = new HashMap<>();
     queryParams.put(SESSION_ID, deliveryRequest.getSessionId());
-    queryParams.put(CLIENT, clientConfig.getClient());
+    queryParams.put(ORGANIZATION_ID, clientConfig.getOrganizationId());
     return queryParams;
   }
 

--- a/src/main/java/com/adobe/target/edge/client/service/DefaultTargetService.java
+++ b/src/main/java/com/adobe/target/edge/client/service/DefaultTargetService.java
@@ -41,7 +41,7 @@ public class DefaultTargetService implements TargetService {
   public static final String SDK_USER_VALUE = "AdobeTargetJava";
   public static final String SDK_VERSION_KEY = "X-EXC-SDK-Version";
   public static final String SESSION_ID = "sessionId";
-  public static final String ORGANIZATION_ID = "organizationId";
+  public static final String ORGANIZATION_ID = "imsOrgId";
   private final TargetHttpClient targetHttpClient;
   private final ClientConfig clientConfig;
   private String stickyLocationHint;

--- a/src/test/java/com/adobe/target/edge/client/ClientConfigTest.java
+++ b/src/test/java/com/adobe/target/edge/client/ClientConfigTest.java
@@ -33,7 +33,7 @@ public class ClientConfigTest {
   @Test
   void testProxyConfigNotSet() {
     ClientConfig clientConfig =
-        ClientConfig.builder().client("emeaprod4").organizationId(TEST_ORG_ID).build();
+        ClientConfig.builder().organizationId(TEST_ORG_ID).build();
     assertFalse(clientConfig.isProxyEnabled());
     assertNull(clientConfig.getProxyConfig());
   }
@@ -42,7 +42,6 @@ public class ClientConfigTest {
   void testProxyConfigSetWithNoAuthentication() {
     ClientConfig clientConfig =
         ClientConfig.builder()
-            .client("emeaprod4")
             .organizationId(TEST_ORG_ID)
             .proxyConfig(new ClientProxyConfig(PROXY_HOST, PROXY_PORT))
             .build();
@@ -60,7 +59,6 @@ public class ClientConfigTest {
   void testProxyConfigSetWithAuthentication() {
     ClientConfig clientConfig =
         ClientConfig.builder()
-            .client("emeaprod4")
             .organizationId(TEST_ORG_ID)
             .proxyConfig(
                 new ClientProxyConfig(PROXY_HOST, PROXY_PORT, PROXY_USERNAME, PROXY_PASSWORD))

--- a/src/test/java/com/adobe/target/edge/client/entities/NotificationDeliveryServiceTest.java
+++ b/src/test/java/com/adobe/target/edge/client/entities/NotificationDeliveryServiceTest.java
@@ -65,7 +65,6 @@ class NotificationDeliveryServiceTest {
 
     clientConfig =
         ClientConfig.builder()
-            .client("emeaprod4")
             .organizationId(TEST_ORG_ID)
             .telemetryEnabled(false)
             .build();

--- a/src/test/java/com/adobe/target/edge/client/entities/TargetDeliveryLocalPropertyTest.java
+++ b/src/test/java/com/adobe/target/edge/client/entities/TargetDeliveryLocalPropertyTest.java
@@ -78,7 +78,7 @@ public class TargetDeliveryLocalPropertyTest {
         .execute(any(Map.class), any(String.class), any(DeliveryRequest.class), any(Class.class));
 
     ClientConfig clientConfig =
-        ClientConfig.builder().client("adobesummit2018").organizationId("org").build();
+        ClientConfig.builder().organizationId("org").build();
 
     DefaultTargetService targetService = new DefaultTargetService(clientConfig);
     OnDeviceDecisioningService localService =

--- a/src/test/java/com/adobe/target/edge/client/entities/TargetDeliveryRequestTest.java
+++ b/src/test/java/com/adobe/target/edge/client/entities/TargetDeliveryRequestTest.java
@@ -63,7 +63,6 @@ class TargetDeliveryRequestTest {
 
     ClientConfig clientConfig =
         ClientConfig.builder()
-            .client("emeaprod4")
             .organizationId(TEST_ORG_ID)
             .defaultPropertyToken(TEST_PROPERTY_TOKEN)
             .build();

--- a/src/test/java/com/adobe/target/edge/client/entities/TargetTelemetryTest.java
+++ b/src/test/java/com/adobe/target/edge/client/entities/TargetTelemetryTest.java
@@ -63,7 +63,6 @@ class TargetTelemetryTest {
 
     clientConfig =
         ClientConfig.builder()
-            .client("emeaprod4")
             .organizationId(TEST_ORG_ID)
             .telemetryEnabled(telemetryEnabled)
             .build();

--- a/src/test/java/com/adobe/target/edge/client/http/DefaultTargetHttpClientTest.java
+++ b/src/test/java/com/adobe/target/edge/client/http/DefaultTargetHttpClientTest.java
@@ -34,7 +34,7 @@ public class DefaultTargetHttpClientTest {
   @Test
   void testProxyConfigNotSet() {
     ClientConfig clientConfig =
-        ClientConfig.builder().client("emeaprod4").organizationId(TEST_ORG_ID).build();
+        ClientConfig.builder().organizationId(TEST_ORG_ID).build();
     DefaultTargetHttpClient targetClient = new DefaultTargetHttpClient(clientConfig);
     UnirestInstance unirestInstance = targetClient.getUnirestInstance();
     Proxy unirestProxy = unirestInstance.config().getProxy();
@@ -46,7 +46,6 @@ public class DefaultTargetHttpClientTest {
   void testProxyConfigSetWithNoAuthentication() {
     ClientConfig clientConfig =
         ClientConfig.builder()
-            .client("emeaprod4")
             .organizationId(TEST_ORG_ID)
             .proxyConfig(new ClientProxyConfig(PROXY_HOST, PROXY_PORT))
             .build();
@@ -65,7 +64,6 @@ public class DefaultTargetHttpClientTest {
   void testProxyConfigSetWithAuthentication() {
     ClientConfig clientConfig =
         ClientConfig.builder()
-            .client("emeaprod4")
             .organizationId(TEST_ORG_ID)
             .proxyConfig(
                 new ClientProxyConfig(PROXY_HOST, PROXY_PORT, PROXY_USERNAME, PROXY_PASSWORD))

--- a/src/test/java/com/adobe/target/edge/client/ondevice/DefaultRuleLoaderTest.java
+++ b/src/test/java/com/adobe/target/edge/client/ondevice/DefaultRuleLoaderTest.java
@@ -76,7 +76,6 @@ class DefaultRuleLoaderTest {
 
     clientConfig =
         ClientConfig.builder()
-            .client("emeaprod4")
             .organizationId(TEST_ORG_ID)
             .onDeviceEnvironment("production")
             .defaultDecisioningMethod(DecisioningMethod.ON_DEVICE)
@@ -284,7 +283,6 @@ class DefaultRuleLoaderTest {
 
     ClientConfig payloadClientConfig =
         ClientConfig.builder()
-            .client("emeaprod4")
             .organizationId(TEST_ORG_ID)
             .onDeviceEnvironment("production")
             .defaultDecisioningMethod(DecisioningMethod.ON_DEVICE)

--- a/src/test/java/com/adobe/target/edge/client/ondevice/client/geo/DefaultGeoClientTest.java
+++ b/src/test/java/com/adobe/target/edge/client/ondevice/client/geo/DefaultGeoClientTest.java
@@ -33,7 +33,6 @@ public class DefaultGeoClientTest {
     String domain = "test.com";
     ClientConfig clientConfig =
         ClientConfig.builder()
-            .client("testclient")
             .organizationId("testOrgId")
             .onDeviceConfigHostname(domain)
             .build();


### PR DESCRIPTION
Removed clientCode URL params to Delivery API from Java SDK

## Description

<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/TNT-38730

## Motivation and Context

A change to Delivery API by Aditi Shete will be deployed on 21 Oct, 2020.  The Delivery API will no longer require BOTH imsOrg and clientCode as params.  Only imsOrg is sufficient because org and client code are 1-1 mapping.

The change to Delivery API would not impact SDK but SDK should be consistent with the backend APIs. 

## How Has This Been Tested?



## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
