### PR TITLE
TNT-39932 - ensure ODD sends notifications async

### DIFF
--- a/src/main/java/com/adobe/target/edge/client/model/TargetAttributesResponse.java
+++ b/src/main/java/com/adobe/target/edge/client/model/TargetAttributesResponse.java
@@ -211,7 +211,8 @@ public class TargetAttributesResponse implements Attributes {
     return option.getType() == OptionType.JSON && contentMap instanceof Map;
   }
 
-  private static Map<String, Map<String, Object>> toReadOnlyMap(Map<String, Map<String, Object>> map) {
+  private static Map<String, Map<String, Object>> toReadOnlyMap(
+      Map<String, Map<String, Object>> map) {
     Map<String, Map<String, Object>> result = new HashMap<>(map.size());
 
     map.keySet().forEach(key -> result.put(key, Collections.unmodifiableMap(map.get(key))));

--- a/src/main/java/com/adobe/target/edge/client/ondevice/NotificationDeliveryService.java
+++ b/src/main/java/com/adobe/target/edge/client/ondevice/NotificationDeliveryService.java
@@ -23,6 +23,6 @@ public class NotificationDeliveryService {
   }
 
   public void sendNotification(final TargetDeliveryRequest deliveryRequest) {
-    this.targetService.executeNotification(deliveryRequest);
+    this.targetService.executeNotificationAsync(deliveryRequest);
   }
 }

--- a/src/test/java/com/adobe/target/edge/client/ClientConfigTest.java
+++ b/src/test/java/com/adobe/target/edge/client/ClientConfigTest.java
@@ -32,8 +32,7 @@ public class ClientConfigTest {
 
   @Test
   void testProxyConfigNotSet() {
-    ClientConfig clientConfig =
-        ClientConfig.builder().organizationId(TEST_ORG_ID).build();
+    ClientConfig clientConfig = ClientConfig.builder().organizationId(TEST_ORG_ID).build();
     assertFalse(clientConfig.isProxyEnabled());
     assertNull(clientConfig.getProxyConfig());
   }

--- a/src/test/java/com/adobe/target/edge/client/entities/NotificationDeliveryServiceTest.java
+++ b/src/test/java/com/adobe/target/edge/client/entities/NotificationDeliveryServiceTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,15 +60,13 @@ class NotificationDeliveryServiceTest {
   void init() throws NoSuchFieldException {
 
     Mockito.lenient()
-        .doReturn(getTestDeliveryResponse())
+        .doReturn(CompletableFuture.completedFuture(getTestDeliveryResponse()))
         .when(defaultTargetHttpClient)
-        .execute(any(Map.class), any(String.class), any(DeliveryRequest.class), any(Class.class));
+        .executeAsync(
+            any(Map.class), any(String.class), any(DeliveryRequest.class), any(Class.class));
 
     clientConfig =
-        ClientConfig.builder()
-            .organizationId(TEST_ORG_ID)
-            .telemetryEnabled(false)
-            .build();
+        ClientConfig.builder().organizationId(TEST_ORG_ID).telemetryEnabled(false).build();
 
     targetService = new DefaultTargetService(clientConfig);
     notificationDeliveryService = new NotificationDeliveryService(targetService);
@@ -110,7 +109,7 @@ class NotificationDeliveryServiceTest {
     TargetDeliveryRequest localDeliveryRequest = localDeliveryRequest();
     notificationDeliveryService.sendNotification(localDeliveryRequest);
     verify(defaultTargetHttpClient, timeout(1000))
-        .execute(
+        .executeAsync(
             any(Map.class),
             any(String.class),
             eq(localDeliveryRequest.getDeliveryRequest()),

--- a/src/test/java/com/adobe/target/edge/client/entities/TargetDeliveryAttributesTest.java
+++ b/src/test/java/com/adobe/target/edge/client/entities/TargetDeliveryAttributesTest.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,9 +63,10 @@ class TargetDeliveryAttributesTest {
   void init() throws IOException, NoSuchFieldException {
 
     Mockito.lenient()
-        .doReturn(getTestDeliveryResponse())
+        .doReturn(CompletableFuture.completedFuture(getTestDeliveryResponse()))
         .when(defaultTargetHttpClient)
-        .execute(any(Map.class), any(String.class), any(DeliveryRequest.class), any(Class.class));
+        .executeAsync(
+            any(Map.class), any(String.class), any(DeliveryRequest.class), any(Class.class));
 
     ClientConfig clientConfig =
         ClientConfig.builder().client("emeaprod4").organizationId(TEST_ORG_ID).build();

--- a/src/test/java/com/adobe/target/edge/client/entities/TargetDeliveryLocalPropertyTest.java
+++ b/src/test/java/com/adobe/target/edge/client/entities/TargetDeliveryLocalPropertyTest.java
@@ -77,8 +77,7 @@ public class TargetDeliveryLocalPropertyTest {
         .when(defaultTargetHttpClient)
         .execute(any(Map.class), any(String.class), any(DeliveryRequest.class), any(Class.class));
 
-    ClientConfig clientConfig =
-        ClientConfig.builder().organizationId("org").build();
+    ClientConfig clientConfig = ClientConfig.builder().organizationId("org").build();
 
     DefaultTargetService targetService = new DefaultTargetService(clientConfig);
     OnDeviceDecisioningService localService =

--- a/src/test/java/com/adobe/target/edge/client/http/DefaultTargetHttpClientTest.java
+++ b/src/test/java/com/adobe/target/edge/client/http/DefaultTargetHttpClientTest.java
@@ -33,8 +33,7 @@ public class DefaultTargetHttpClientTest {
 
   @Test
   void testProxyConfigNotSet() {
-    ClientConfig clientConfig =
-        ClientConfig.builder().organizationId(TEST_ORG_ID).build();
+    ClientConfig clientConfig = ClientConfig.builder().organizationId(TEST_ORG_ID).build();
     DefaultTargetHttpClient targetClient = new DefaultTargetHttpClient(clientConfig);
     UnirestInstance unirestInstance = targetClient.getUnirestInstance();
     Proxy unirestProxy = unirestInstance.config().getProxy();

--- a/src/test/java/com/adobe/target/edge/client/ondevice/client/geo/DefaultGeoClientTest.java
+++ b/src/test/java/com/adobe/target/edge/client/ondevice/client/geo/DefaultGeoClientTest.java
@@ -32,10 +32,7 @@ public class DefaultGeoClientTest {
   void testDefaultGeoClient() {
     String domain = "test.com";
     ClientConfig clientConfig =
-        ClientConfig.builder()
-            .organizationId("testOrgId")
-            .onDeviceConfigHostname(domain)
-            .build();
+        ClientConfig.builder().organizationId("testOrgId").onDeviceConfigHostname(domain).build();
     DefaultGeoClient geoClient = spy(DefaultGeoClient.class);
     geoClient.start(clientConfig);
 


### PR DESCRIPTION
Make sure ODD execution sends notifications asynchronously

## Description

Make sure ODD execution sends notifications asynchronously

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When using ODD for `execute` request we should send notifications immediately. However the current implementation relies on a blocking call to send notifications, which means that even if the activity evaluation is using on-device the `getOffers()` method would still wait until the send notification blocking call would complete. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using existing test

## Screenshots (if appropriate):
None

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
