### PR TITLE
TNT-40731 - fix TargetMetrics error handling and bumping ECID version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.1.4] - 2021-04-20
+### Changed
+- Fix incorrect handling of error scenario in `TargetMetrics.begin()`
+- Updating ECID Service version
+
 ## [2.1.3] - 2021-03-04
 ### Changed
 - (On Device Decisioning) Updated the bucketing algorithm to be consistent across all platforms

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ signing {
 }
 
 dependencies {
-    api "com.adobe.experiencecloud.ecid:ecid-service:1.0.1"
+    api "com.adobe.experiencecloud.ecid:ecid-service:1.0.2"
     implementation "org.slf4j:slf4j-api:1.7.30"
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.11.3"
     implementation "com.fasterxml.jackson.core:jackson-core:2.11.3"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.adobe.target
-version=2.1.3
+version=2.1.4
 mavenCentralUrl=https://oss.sonatype.org/service/local/staging/deploy/maven2
 pomDescription=Adobe Target Java SDK
 pomURL=https://docs.adobe.com/content/help/en/target/using/implement-target/server-side/api-and-sdk-overview.html

--- a/src/test/java/com/adobe/target/edge/client/http/TargetMetricsTest.java
+++ b/src/test/java/com/adobe/target/edge/client/http/TargetMetricsTest.java
@@ -1,0 +1,50 @@
+package com.adobe.target.edge.client.http;
+
+import kong.unirest.HttpRequestSummary;
+import kong.unirest.HttpResponseSummary;
+import kong.unirest.MetricContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.function.Consumer;
+
+@ExtendWith(MockitoExtension.class)
+public class TargetMetricsTest {
+
+  private Consumer<TargetMetricContext> consumer;
+  private HttpRequestSummary request;
+  private HttpResponseSummary response;
+
+  @BeforeEach
+  void init() {
+    consumer = mock(Consumer.class);
+    request = mock(HttpRequestSummary.class);
+    response = mock(HttpResponseSummary.class);
+  }
+
+  @Test
+  public void testMetricsAreAcceptedWhenNoException() {
+    TargetMetrics targetMetrics = new TargetMetrics(consumer);
+    MetricContext metricContext = targetMetrics.begin(request);
+
+    metricContext.complete(response, null);
+
+    verify(consumer, times(1)).accept(any(TargetMetricContext.class));
+  }
+
+  @Test
+  public void testMetricsAreNotAcceptedWhenException() {
+    TargetMetrics targetMetrics = new TargetMetrics(consumer);
+    MetricContext metricContext = targetMetrics.begin(request);
+
+    metricContext.complete(null, new Exception());
+
+    verify(consumer, times(0)).accept(any(TargetMetricContext.class));
+  }
+
+}


### PR DESCRIPTION
Fix incorrect error handling in `TargetMetrics.begin()` and ECID upgrade

## Description

Fix incorrect error handling in `TargetMetrics.begin()` and ECID upgrade

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix incorrect error handling in `TargetMetrics.begin()` and ECID upgrade

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests are provided for the fix.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
