### PR TITLE
TNT-40998 Fix MaxAge in response cookies should be a time span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [2.1.5] - 2021-05-06
+## [2.1.5] - 2021-05-18
 ### Changed
 - Fix incorrect MaxAge set in response cookies
 

--- a/src/main/java/com/adobe/target/edge/client/model/TargetDeliveryResponse.java
+++ b/src/main/java/com/adobe/target/edge/client/model/TargetDeliveryResponse.java
@@ -50,12 +50,12 @@ public class TargetDeliveryResponse {
             || response.getStatus() == HttpStatus.SC_PARTIAL_CONTENT)) {
       return Collections.EMPTY_LIST;
     }
-    List<TargetCookie> requestCookies = new ArrayList<>();
+    List<TargetCookie> responseCookies = new ArrayList<>();
     CookieUtils.createTargetCookie(request.getSessionId(), response.getId().getTntId())
-        .ifPresent(targetCookie -> requestCookies.add(targetCookie));
+        .ifPresent(targetCookie -> responseCookies.add(targetCookie));
     CookieUtils.createClusterCookie(response.getId().getTntId())
-        .ifPresent(clusterCookie -> requestCookies.add(clusterCookie));
-    return requestCookies;
+        .ifPresent(clusterCookie -> responseCookies.add(clusterCookie));
+    return responseCookies;
   }
 
   public Map<String, VisitorState> getVisitorState() {

--- a/src/main/java/com/adobe/target/edge/client/utils/CookieUtils.java
+++ b/src/main/java/com/adobe/target/edge/client/utils/CookieUtils.java
@@ -93,11 +93,12 @@ public class CookieUtils {
   public static Optional<TargetCookie> createTargetCookie(String sessionId, String deviceId) {
     final int nowInSeconds = getNowInSeconds();
     final StringBuilder targetCookieValue = new StringBuilder();
-    int maxAge = 0;
-    maxAge = createSessionId(sessionId, nowInSeconds, targetCookieValue, maxAge);
-    maxAge = createDeviceId(deviceId, nowInSeconds, targetCookieValue, maxAge);
+    int expires = 0;
+    expires = createSessionId(sessionId, nowInSeconds, targetCookieValue, expires);
+    expires = createDeviceId(deviceId, nowInSeconds, targetCookieValue, expires);
     TargetCookie targetCookie = null;
     String cookieValue = targetCookieValue.toString();
+    int maxAge = expires == 0 ? 0 : expires - nowInSeconds;
 
     if (isNotEmpty(cookieValue)) {
       targetCookie = new TargetCookie(COOKIE_NAME, cookieValue, maxAge);
@@ -111,38 +112,38 @@ public class CookieUtils {
   }
 
   private static int createDeviceId(
-      String deviceId, int nowInSeconds, StringBuilder targetCookieValue, int maxAge) {
+      String deviceId, int nowInSeconds, StringBuilder targetCookieValue, int expires) {
     if (isEmpty(deviceId)) {
-      return maxAge;
+      return expires;
     }
 
-    int deviceIdMaxAge = nowInSeconds + DEVICE_ID_COOKIE_MAX_AGE;
-    maxAge = Math.max(maxAge, deviceIdMaxAge);
-    appendCookieValue(deviceId, targetCookieValue, deviceIdMaxAge, DEVICE_ID_COOKIE_NAME);
+    int deviceIdExpires = nowInSeconds + DEVICE_ID_COOKIE_MAX_AGE;
+    expires = Math.max(expires, deviceIdExpires);
+    appendCookieValue(deviceId, targetCookieValue, deviceIdExpires, DEVICE_ID_COOKIE_NAME);
 
-    return maxAge;
+    return expires;
   }
 
   private static int createSessionId(
-      String sessionId, int nowInSeconds, StringBuilder targetCookieValue, int maxAge) {
+      String sessionId, int nowInSeconds, StringBuilder targetCookieValue, int expires) {
     if (isEmpty(sessionId)) {
-      return maxAge;
+      return expires;
     }
 
-    int sessionIdMaxAge = nowInSeconds + SESSION_ID_COOKIE_MAX_AGE;
-    maxAge = sessionIdMaxAge;
-    appendCookieValue(sessionId, targetCookieValue, sessionIdMaxAge, SESSION_ID_COOKIE_NAME);
-    return maxAge;
+    int sessionIdExpires = nowInSeconds + SESSION_ID_COOKIE_MAX_AGE;
+    expires = sessionIdExpires;
+    appendCookieValue(sessionId, targetCookieValue, sessionIdExpires, SESSION_ID_COOKIE_NAME);
+    return expires;
   }
 
   private static void appendCookieValue(
-      String id, StringBuilder targetCookieValue, int maxAge, String cookieName) {
+      String id, StringBuilder targetCookieValue, int expires, String cookieName) {
     targetCookieValue
         .append(cookieName)
         .append(INTERNAL_COOKIE_SERIALIZATION_SEPARATOR)
         .append(id)
         .append(INTERNAL_COOKIE_SERIALIZATION_SEPARATOR)
-        .append(maxAge)
+        .append(expires)
         .append(COOKIE_VALUE_SEPARATOR);
   }
 
@@ -153,8 +154,7 @@ public class CookieUtils {
     TargetCookie targetCookie = null;
     String locationHint = locationHintFromTntId(tntId);
     if (locationHint != null) {
-      int maxAge = getNowInSeconds() + CLUSTER_LOCATION_HINT_MAX_AGE;
-      targetCookie = new TargetCookie(CLUSTER_COOKIE_NAME, locationHint, maxAge);
+      targetCookie = new TargetCookie(CLUSTER_COOKIE_NAME, locationHint, CLUSTER_LOCATION_HINT_MAX_AGE);
     }
     return Optional.ofNullable(targetCookie);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Max Age in response cookies is a Unix timestamp (as required for Expires header) instead of being a time span in seconds.
This should be fixed, so Max Age time span in response cookies equals Expires - now().

## Related Issue

https://jira.corp.adobe.com/browse/TNT-40998
