### PR TITLE
TNT-43530 - ensure context.beacon = false for all sendNotifications calls

### DIFF
--- a/src/main/java/com/adobe/target/edge/client/service/DefaultTargetService.java
+++ b/src/main/java/com/adobe/target/edge/client/service/DefaultTargetService.java
@@ -13,7 +13,6 @@ package com.adobe.target.edge.client.service;
 
 import static com.adobe.target.edge.client.ondevice.OnDeviceDecisioningService.TIMING_EXECUTE_REQUEST;
 import static com.adobe.target.edge.client.utils.TargetConstants.SDK_VERSION;
-import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_OK;
 
 import com.adobe.target.delivery.v1.model.DeliveryResponse;
@@ -115,9 +114,9 @@ public class DefaultTargetService implements TargetService {
 
   @Override
   public ResponseStatus executeNotification(TargetDeliveryRequest deliveryRequest) {
-
     TimingTool timer = new TimingTool();
     timer.timeStart(TIMING_EXECUTE_REQUEST);
+    NotificationService.setBeaconToFalse(deliveryRequest.getDeliveryRequest());
     TargetDeliveryResponse targetDeliveryResponse;
     Telemetry telemetry = telemetryService.getTelemetry();
     if (!telemetry.getEntries().isEmpty()) {
@@ -141,6 +140,7 @@ public class DefaultTargetService implements TargetService {
       TargetDeliveryRequest deliveryRequest) {
     TimingTool timer = new TimingTool();
     timer.timeStart(TIMING_EXECUTE_REQUEST);
+    NotificationService.setBeaconToFalse(deliveryRequest.getDeliveryRequest());
     Telemetry telemetry = telemetryService.getTelemetry();
     if (!telemetry.getEntries().isEmpty()) {
       deliveryRequest.getDeliveryRequest().setTelemetry(telemetry);
@@ -179,9 +179,7 @@ public class DefaultTargetService implements TargetService {
 
   private DeliveryResponse retrieveDeliveryResponse(HttpResponse<DeliveryResponse> response) {
     DeliveryResponse deliveryResponse = response.getBody();
-    /* We expect an empty response body and 204 status code when request includes
-    Context.beacon=true */
-    if (deliveryResponse == null && response.getStatus() != SC_NO_CONTENT) {
+    if (deliveryResponse == null) {
       Optional<UnirestParsingException> parsingError = response.getParsingError();
 
       throw new RuntimeException(

--- a/src/main/java/com/adobe/target/edge/client/service/DefaultTargetService.java
+++ b/src/main/java/com/adobe/target/edge/client/service/DefaultTargetService.java
@@ -13,6 +13,7 @@ package com.adobe.target.edge.client.service;
 
 import static com.adobe.target.edge.client.ondevice.OnDeviceDecisioningService.TIMING_EXECUTE_REQUEST;
 import static com.adobe.target.edge.client.utils.TargetConstants.SDK_VERSION;
+import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_OK;
 
 import com.adobe.target.delivery.v1.model.DeliveryResponse;
@@ -178,7 +179,9 @@ public class DefaultTargetService implements TargetService {
 
   private DeliveryResponse retrieveDeliveryResponse(HttpResponse<DeliveryResponse> response) {
     DeliveryResponse deliveryResponse = response.getBody();
-    if (deliveryResponse == null) {
+    /* We expect an empty response body and 204 status code when request includes
+    Context.beacon=true */
+    if (deliveryResponse == null && response.getStatus() != SC_NO_CONTENT) {
       Optional<UnirestParsingException> parsingError = response.getParsingError();
 
       throw new RuntimeException(

--- a/src/main/java/com/adobe/target/edge/client/service/NotificationService.java
+++ b/src/main/java/com/adobe/target/edge/client/service/NotificationService.java
@@ -11,6 +11,7 @@
  */
 package com.adobe.target.edge.client.service;
 
+import com.adobe.target.delivery.v1.model.Context;
 import com.adobe.target.delivery.v1.model.DeliveryRequest;
 import com.adobe.target.delivery.v1.model.Notification;
 import com.adobe.target.edge.client.ClientConfig;
@@ -48,6 +49,7 @@ public class NotificationService {
       return;
     }
     DeliveryRequest deliveryRequest = targetDeliveryRequest.getDeliveryRequest();
+    setBeaconToFalse(deliveryRequest);
     String locationHint =
         targetDeliveryRequest.getLocationHint() != null
             ? targetDeliveryRequest.getLocationHint()
@@ -73,5 +75,12 @@ public class NotificationService {
             .trace(deliveryRequest.getTrace())
             .build();
     this.sendNotification(notificationRequest);
+  }
+
+  public static void setBeaconToFalse(DeliveryRequest deliveryRequest) {
+    Context context = deliveryRequest.getContext();
+    if (context != null && context.getBeacon() != Boolean.valueOf(false)) {
+      context.setBeacon(false);
+    }
   }
 }

--- a/src/main/java/com/adobe/target/edge/client/service/NotificationService.java
+++ b/src/main/java/com/adobe/target/edge/client/service/NotificationService.java
@@ -79,7 +79,7 @@ public class NotificationService {
 
   public static void setBeaconToFalse(DeliveryRequest deliveryRequest) {
     Context context = deliveryRequest.getContext();
-    if (context != null && context.getBeacon() != Boolean.valueOf(false)) {
+    if (context.getBeacon() == null || context.getBeacon()) {
       context.setBeacon(false);
     }
   }

--- a/src/main/java/com/adobe/target/edge/client/service/TelemetryService.java
+++ b/src/main/java/com/adobe/target/edge/client/service/TelemetryService.java
@@ -95,7 +95,7 @@ public class TelemetryService {
       TargetDeliveryRequest targetDeliveryRequest,
       TargetDeliveryResponse targetDeliveryResponse,
       double executionTime) {
-    if (!clientConfig.isTelemetryEnabled()) {
+    if (!clientConfig.isTelemetryEnabled() || targetDeliveryResponse.getResponse() == null) {
       return null;
     }
 

--- a/src/test/java/com/adobe/target/edge/client/http/DefaultTargetHttpClientTest.java
+++ b/src/test/java/com/adobe/target/edge/client/http/DefaultTargetHttpClientTest.java
@@ -30,6 +30,7 @@ import kong.unirest.HttpResponse;
 import kong.unirest.Proxy;
 import kong.unirest.RawResponse;
 import kong.unirest.UnirestInstance;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
@@ -115,7 +116,8 @@ public class DefaultTargetHttpClientTest {
             .asObject(ArgumentMatchers.<Function<RawResponse, Object>>any()))
         .thenAnswer(
             invocation -> {
-              RawResponse rawResponse = TargetTestDeliveryRequestUtils.getRawTestResponse();
+              RawResponse rawResponse =
+                  TargetTestDeliveryRequestUtils.getRawTestResponse(HttpStatus.SC_OK);
               Function<RawResponse, Object> function =
                   (Function<RawResponse, Object>) invocation.getArguments()[0];
               function.apply(rawResponse);

--- a/src/test/java/com/adobe/target/edge/client/service/DefaultTargetServiceTest.java
+++ b/src/test/java/com/adobe/target/edge/client/service/DefaultTargetServiceTest.java
@@ -154,7 +154,7 @@ public class DefaultTargetServiceTest {
         .execute(any(Map.class), any(String.class), any(DeliveryRequest.class), any(Class.class));
 
     TargetDeliveryRequest targetDeliveryRequestMock = getDeliveryRequest();
-    targetDeliveryRequestMock.getDeliveryRequest().getContext().setBeacon(Boolean.valueOf(true));
+    targetDeliveryRequestMock.getDeliveryRequest().getContext().setBeacon(true);
     targetService.executeNotification(targetDeliveryRequestMock);
 
     ArgumentCaptor<DeliveryRequest> captor = ArgumentCaptor.forClass(DeliveryRequest.class);

--- a/src/test/java/com/adobe/target/edge/client/service/TelemetryServiceTest.java
+++ b/src/test/java/com/adobe/target/edge/client/service/TelemetryServiceTest.java
@@ -21,8 +21,8 @@ import static com.adobe.target.edge.client.utils.TargetTestDeliveryRequestUtils.
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEFAULTS;
 import static org.mockito.Mockito.atLeast;
@@ -339,7 +339,8 @@ class TelemetryServiceTest {
     TargetDeliveryRequest targetDeliveryRequest =
         TargetDeliveryRequest.builder().context(context).notifications(notifications).build();
 
-    assertThrows(RuntimeException.class, () -> targetJavaClient.sendNotifications(targetDeliveryRequest));
+    assertThrows(
+        RuntimeException.class, () -> targetJavaClient.sendNotifications(targetDeliveryRequest));
 
     verify(telemetryServiceSpy, never())
         .addTelemetry(

--- a/src/test/java/com/adobe/target/edge/client/service/TelemetryServiceTest.java
+++ b/src/test/java/com/adobe/target/edge/client/service/TelemetryServiceTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEFAULTS;
 import static org.mockito.Mockito.atLeast;
@@ -338,10 +339,7 @@ class TelemetryServiceTest {
     TargetDeliveryRequest targetDeliveryRequest =
         TargetDeliveryRequest.builder().context(context).notifications(notifications).build();
 
-    try {
-      targetJavaClient.sendNotifications(targetDeliveryRequest);
-    } catch (RuntimeException e) {
-    }
+    assertThrows(RuntimeException.class, () -> targetJavaClient.sendNotifications(targetDeliveryRequest));
 
     verify(telemetryServiceSpy, never())
         .addTelemetry(

--- a/src/test/java/com/adobe/target/edge/client/utils/TargetTestDeliveryRequestUtils.java
+++ b/src/test/java/com/adobe/target/edge/client/utils/TargetTestDeliveryRequestUtils.java
@@ -262,7 +262,7 @@ public class TargetTestDeliveryRequestUtils {
   }
 
   public static ResponseWrapper<DeliveryResponse> getNoContentDeliveryResponse() {
-    RawResponse rawResponse = getRawTestResponse(HttpStatus.SC_NO_CONTENT);
+    RawResponse rawResponse = getRawTestResponse(HttpStatus.SC_GATEWAY_TIMEOUT);
     ResponseWrapper<DeliveryResponse> responseWrapper = new ResponseWrapper<>();
     responseWrapper.setHttpResponse(new BasicResponse<>(rawResponse, null));
     return responseWrapper;

--- a/src/test/java/com/adobe/target/edge/client/utils/TargetTestDeliveryRequestUtils.java
+++ b/src/test/java/com/adobe/target/edge/client/utils/TargetTestDeliveryRequestUtils.java
@@ -192,11 +192,11 @@ public class TargetTestDeliveryRequestUtils {
     return Arrays.asList(prefetchMboxResponse);
   }
 
-  public static RawResponse getRawTestResponse() {
+  public static RawResponse getRawTestResponse(int statusCode) {
     return new RawResponse() {
       @Override
       public int getStatus() {
-        return HttpStatus.SC_OK;
+        return statusCode;
       }
 
       @Override
@@ -261,6 +261,13 @@ public class TargetTestDeliveryRequestUtils {
     };
   }
 
+  public static ResponseWrapper<DeliveryResponse> getNoContentDeliveryResponse() {
+    RawResponse rawResponse = getRawTestResponse(HttpStatus.SC_NO_CONTENT);
+    ResponseWrapper<DeliveryResponse> responseWrapper = new ResponseWrapper<>();
+    responseWrapper.setHttpResponse(new BasicResponse<>(rawResponse, null));
+    return responseWrapper;
+  }
+
   public static ResponseWrapper<DeliveryResponse> getTestDeliveryResponse() {
     DeliveryResponse deliveryResponse =
         new DeliveryResponse() {
@@ -280,7 +287,7 @@ public class TargetTestDeliveryRequestUtils {
 
   static ResponseWrapper<DeliveryResponse> getTestDeliveryResponse(
       DeliveryResponse deliveryResponse) {
-    RawResponse rawResponse = getRawTestResponse();
+    RawResponse rawResponse = getRawTestResponse(HttpStatus.SC_OK);
     ResponseWrapper<DeliveryResponse> responseWrapper = new ResponseWrapper<>();
     responseWrapper.setParsingTime(200);
     responseWrapper.setResponseSize(119);
@@ -290,7 +297,7 @@ public class TargetTestDeliveryRequestUtils {
 
   public static ResponseWrapper<DeliveryResponse> getTestDeliveryResponseFailure(
       String errorMessage, String ogBody) {
-    RawResponse rawResponse = getRawTestResponse();
+    RawResponse rawResponse = getRawTestResponse(HttpStatus.SC_BAD_REQUEST);
     ResponseWrapper<DeliveryResponse> responseWrapper = new ResponseWrapper<>();
     responseWrapper.setParsingTime(200);
     responseWrapper.setResponseSize(0);


### PR DESCRIPTION
A customer noticed an error when parsing the response of a sendNotifications calls when setting context.beacon=true.  Setting that to true doesn't make sense for a server-side SDK, so we should always set it to false if the customer has tried to set it.  This way we get an actual response back from Delivery API and no parsing exception.

While testing this I also noticed that when we get a null response from Delivery API we end up with an NPE in the TelemetryService.  I've added an additional check in TelemetryService to avoid that NPE in case there are other edge cases in which the response is null.

https://jira.corp.adobe.com/browse/TNT-43530

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
