### PR TITLE
TNT-40162 initial fix for TLD and subdomain bug using guava InternetDomainName

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:2.11.3"
     implementation "com.konghq:unirest-java:3.11.02"
     implementation "io.github.jamsesso:json-logic-java:1.0.5"
+    implementation "com.google.guava:guava:16.0.1"
 
     testImplementation "org.slf4j:slf4j-simple:1.7.30"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:5.5.2"

--- a/src/main/java/com/adobe/target/edge/client/ondevice/collator/PageParamsCollator.java
+++ b/src/main/java/com/adobe/target/edge/client/ondevice/collator/PageParamsCollator.java
@@ -112,11 +112,12 @@ public class PageParamsCollator implements ParamsCollator {
     if (host == null) {
       return "";
     }
-    if (host.toLowerCase().startsWith("www.")) {
+    String lowerCaseHost = host.toLowerCase();
+    if (lowerCaseHost.startsWith("www.")) {
+      lowerCaseHost = lowerCaseHost.substring(4);
       host = host.substring(4);
     }
-    String lowerCaseHost = host.toLowerCase();
-    InternetDomainName domain = InternetDomainName.from(host);
+    InternetDomainName domain = InternetDomainName.from(lowerCaseHost);
     if (!domain.hasPublicSuffix()) {
       return "";
     }
@@ -124,11 +125,8 @@ public class PageParamsCollator implements ParamsCollator {
     if (lowerCaseHost.indexOf(topPrivateDomain) == 0) {
       return "";
     }
-    String lowerCaseResult = lowerCaseHost.substring(0, lowerCaseHost.indexOf(topPrivateDomain) - 1);
-    if (lowerCaseHost.equals(host)) {
-      return lowerCaseResult;
-    }
-    return lowerCaseResult.toUpperCase();
+    int endIndex = lowerCaseHost.indexOf(topPrivateDomain) - 1;
+    return host.substring(0, endIndex);
   }
 
   private String strOrBlank(String str) {

--- a/src/main/java/com/adobe/target/edge/client/ondevice/collator/PageParamsCollator.java
+++ b/src/main/java/com/adobe/target/edge/client/ondevice/collator/PageParamsCollator.java
@@ -14,6 +14,7 @@ package com.adobe.target.edge.client.ondevice.collator;
 import com.adobe.target.delivery.v1.model.*;
 import com.adobe.target.edge.client.model.TargetDeliveryRequest;
 import com.adobe.target.edge.client.utils.StringUtils;
+import com.google.common.net.InternetDomainName;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
@@ -95,26 +96,36 @@ public class PageParamsCollator implements ParamsCollator {
     if (host == null) {
       return "";
     }
-    int idx = host.lastIndexOf('.');
-    if (idx >= 0 && host.length() > 1) {
-      return host.substring(idx + 1);
+    String lowerCaseHost = host.toLowerCase();
+    InternetDomainName publicSuffix = InternetDomainName.from(host).publicSuffix();
+    if (publicSuffix == null) {
+      return "";
     }
-    return host;
+    String lowerCaseResult = publicSuffix.toString();
+    if (lowerCaseHost.equals(host)) {
+      return lowerCaseResult;
+    }
+    return lowerCaseResult.toUpperCase();
   }
 
   private String extractSubDomain(String host) {
-    // TODO: implement properly
     if (host == null) {
       return "";
     }
-    if (host.toLowerCase().startsWith("www.")) {
-      host = host.substring(4);
-    }
-    String[] parts = host.split("\\.");
-    if (parts.length < 3) {
+    String lowerCaseHost = host.toLowerCase();
+    InternetDomainName domain = InternetDomainName.from(host);
+    if (!domain.hasPublicSuffix()) {
       return "";
     }
-    return parts[0];
+    String topPrivateDomain = domain.topPrivateDomain().toString();
+    if (lowerCaseHost.indexOf(topPrivateDomain) == 0) {
+      return "";
+    }
+    String lowerCaseResult = lowerCaseHost.substring(0, lowerCaseHost.indexOf(topPrivateDomain) - 1);
+    if (lowerCaseHost.equals(host)) {
+      return lowerCaseResult;
+    }
+    return lowerCaseResult.toUpperCase();
   }
 
   private String strOrBlank(String str) {

--- a/src/main/java/com/adobe/target/edge/client/ondevice/collator/PageParamsCollator.java
+++ b/src/main/java/com/adobe/target/edge/client/ondevice/collator/PageParamsCollator.java
@@ -122,11 +122,11 @@ public class PageParamsCollator implements ParamsCollator {
       return "";
     }
     String topPrivateDomain = domain.topPrivateDomain().toString();
-    if (lowerCaseHost.indexOf(topPrivateDomain) == 0) {
+    int endIndex = lowerCaseHost.indexOf(topPrivateDomain);
+    if (endIndex == 0) {
       return "";
     }
-    int endIndex = lowerCaseHost.indexOf(topPrivateDomain) - 1;
-    return host.substring(0, endIndex);
+    return host.substring(0, endIndex - 1);
   }
 
   private String strOrBlank(String str) {

--- a/src/main/java/com/adobe/target/edge/client/ondevice/collator/PageParamsCollator.java
+++ b/src/main/java/com/adobe/target/edge/client/ondevice/collator/PageParamsCollator.java
@@ -112,6 +112,9 @@ public class PageParamsCollator implements ParamsCollator {
     if (host == null) {
       return "";
     }
+    if (host.toLowerCase().startsWith("www.")) {
+      host = host.substring(4);
+    }
     String lowerCaseHost = host.toLowerCase();
     InternetDomainName domain = InternetDomainName.from(host);
     if (!domain.hasPublicSuffix()) {

--- a/src/test/java/com/adobe/target/edge/client/ondevice/collator/PageParamsCollatorTest.java
+++ b/src/test/java/com/adobe/target/edge/client/ondevice/collator/PageParamsCollatorTest.java
@@ -44,8 +44,8 @@ public class PageParamsCollatorTest {
     assertEquals("/about/", result.get(PageParamsCollator.PAGE_PATH_LOWER));
     assertEquals("WWW.TARGET.ADOBE.COM", result.get(PageParamsCollator.PAGE_DOMAIN));
     assertEquals("www.target.adobe.com", result.get(PageParamsCollator.PAGE_DOMAIN_LOWER));
-    assertEquals("WWW.TARGET", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
-    assertEquals("www.target", result.get(PageParamsCollator.PAGE_SUBDOMAIN_LOWER));
+    assertEquals("TARGET", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
+    assertEquals("target", result.get(PageParamsCollator.PAGE_SUBDOMAIN_LOWER));
     assertEquals("COM", result.get(PageParamsCollator.PAGE_TOP_LEVEL_DOMAIN));
     assertEquals("com", result.get(PageParamsCollator.PAGE_TOP_LEVEL_DOMAIN_LOWER));
     assertEquals("foo=bar&name=JimmyG", result.get(PageParamsCollator.PAGE_QUERY));
@@ -67,7 +67,7 @@ public class PageParamsCollatorTest {
         .build();
     PageParamsCollator collator = new PageParamsCollator();
     Map<String, Object> result = collator.collateParams(request, pageLoad);
-    assertEquals("www", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
+    assertEquals("", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
     assertEquals("co.uk", result.get(PageParamsCollator.PAGE_TOP_LEVEL_DOMAIN));
 
     url = "https://test.co.uk";
@@ -97,7 +97,7 @@ public class PageParamsCollatorTest {
         .context(new Context().address(new Address().url(url)))
         .build();
     result = collator.collateParams(request, pageLoad);
-    assertEquals("www", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
+    assertEquals("", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
     assertEquals("ide.kyoto.jp", result.get(PageParamsCollator.PAGE_TOP_LEVEL_DOMAIN));
 
     url = "http://localhost:3000/";

--- a/src/test/java/com/adobe/target/edge/client/ondevice/collator/PageParamsCollatorTest.java
+++ b/src/test/java/com/adobe/target/edge/client/ondevice/collator/PageParamsCollatorTest.java
@@ -44,13 +44,70 @@ public class PageParamsCollatorTest {
     assertEquals("/about/", result.get(PageParamsCollator.PAGE_PATH_LOWER));
     assertEquals("WWW.TARGET.ADOBE.COM", result.get(PageParamsCollator.PAGE_DOMAIN));
     assertEquals("www.target.adobe.com", result.get(PageParamsCollator.PAGE_DOMAIN_LOWER));
-    assertEquals("TARGET", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
-    assertEquals("target", result.get(PageParamsCollator.PAGE_SUBDOMAIN_LOWER));
+    assertEquals("WWW.TARGET", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
+    assertEquals("www.target", result.get(PageParamsCollator.PAGE_SUBDOMAIN_LOWER));
     assertEquals("COM", result.get(PageParamsCollator.PAGE_TOP_LEVEL_DOMAIN));
     assertEquals("com", result.get(PageParamsCollator.PAGE_TOP_LEVEL_DOMAIN_LOWER));
     assertEquals("foo=bar&name=JimmyG", result.get(PageParamsCollator.PAGE_QUERY));
     assertEquals("foo=bar&name=jimmyg", result.get(PageParamsCollator.PAGE_QUERY_LOWER));
     assertEquals("Part1", result.get(PageParamsCollator.PAGE_FRAGMENT));
     assertEquals("part1", result.get(PageParamsCollator.PAGE_FRAGMENT_LOWER));
+  }
+
+  @Test
+  public void testSubdomainAndTLDParse() {
+    VisitorProvider.init("testOrgId");
+    String url = "http://www.amazon.co.uk";
+
+    RequestDetails pageLoad = new RequestDetails();
+    TargetDeliveryRequest request =
+      TargetDeliveryRequest.builder()
+        .execute(new ExecuteRequest().pageLoad(pageLoad))
+        .context(new Context().address(new Address().url(url)))
+        .build();
+    PageParamsCollator collator = new PageParamsCollator();
+    Map<String, Object> result = collator.collateParams(request, pageLoad);
+    assertEquals("www", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
+    assertEquals("co.uk", result.get(PageParamsCollator.PAGE_TOP_LEVEL_DOMAIN));
+
+    url = "https://test.co.uk";
+    request =
+      TargetDeliveryRequest.builder()
+        .execute(new ExecuteRequest().pageLoad(pageLoad))
+        .context(new Context().address(new Address().url(url)))
+        .build();
+    result = collator.collateParams(request, pageLoad);
+    assertEquals("", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
+    assertEquals("co.uk", result.get(PageParamsCollator.PAGE_TOP_LEVEL_DOMAIN));
+
+    url = "https://sub.test.co.uk";
+    request =
+      TargetDeliveryRequest.builder()
+        .execute(new ExecuteRequest().pageLoad(pageLoad))
+        .context(new Context().address(new Address().url(url)))
+        .build();
+    result = collator.collateParams(request, pageLoad);
+    assertEquals("sub", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
+    assertEquals("co.uk", result.get(PageParamsCollator.PAGE_TOP_LEVEL_DOMAIN));
+
+    url = "https://www.town.ide.kyoto.jp/";
+    request =
+      TargetDeliveryRequest.builder()
+        .execute(new ExecuteRequest().pageLoad(pageLoad))
+        .context(new Context().address(new Address().url(url)))
+        .build();
+    result = collator.collateParams(request, pageLoad);
+    assertEquals("www", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
+    assertEquals("ide.kyoto.jp", result.get(PageParamsCollator.PAGE_TOP_LEVEL_DOMAIN));
+
+    url = "http://localhost:3000/";
+    request =
+      TargetDeliveryRequest.builder()
+        .execute(new ExecuteRequest().pageLoad(pageLoad))
+        .context(new Context().address(new Address().url(url)))
+        .build();
+    result = collator.collateParams(request, pageLoad);
+    assertEquals("", result.get(PageParamsCollator.PAGE_SUBDOMAIN));
+    assertEquals("", result.get(PageParamsCollator.PAGE_TOP_LEVEL_DOMAIN));
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The current implementation of extracting subdomains and Top-Level domains does not work in all instances, `ex .co.uk`. This PR utilizes the InternetDomainName class from Google's guava to parse domain names. 

## Related Issue

https://jira.corp.adobe.com/browse/TNT-40162

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
